### PR TITLE
Doc Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
     container:
       image: ${{ needs.docker-tag.outputs.container-uri }}
       credentials:
-        username: BOT_ACCOUNT_USERNAME
+        username: ASFOpenSARlab-bot
         password: ${{ secrets.PAT_PACKAGES_READ_ONLY }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There's also the docs from here, we could consider migrating here:
- https://github.com/ASFOpenSARlab/deployment-opensciencelab-prod-portal/tree/main/.github/workflows#readme
But I'm not sure which chunks would be better here, vs staying in that repo. I guess technically, that info will be true for all repos we automate, so it should go here?